### PR TITLE
To use js-inflate with Appcelerator Titanium

### DIFF
--- a/js-inflate.js
+++ b/js-inflate.js
@@ -729,6 +729,25 @@
         GLOBAL.JSInflate = JSInflate;
     }
 
+    JSInflate.inflateArray = function (data) {
+        var out, buff;
+        var i, j;
+
+        zip_inflate_start();
+        zip_inflate_data = data;
+        zip_inflate_pos = 0;
+
+        buff = new Array(1024);
+        out = [];
+        while((i = zip_inflate_internal(buff, 0, buff.length)) > 0) {
+            for(j = 0; j < i; j++){
+                out.push(buff[j]);
+            }
+        }
+        zip_inflate_data = null; // G.C.
+
+        return out;
+    };
     JSInflate.inflate = function (data) {
         var out, buff;
         var i, j;


### PR DESCRIPTION
Hi, thanks for the great code!

I added a new function, inflateArray, for use in non-browser platforms with weird string behaviours, like Titanium Developer.

Titanium tries to convert every string in IO operations to UTF-8. Obviously, this causes inflate unusable. You can use inflateArray to obtain the extracted bytes you want to write to filesystem.
